### PR TITLE
feat(): add native pino levels for injection to fastify adapter

### DIFF
--- a/lib/loggers/pino.logger.ts
+++ b/lib/loggers/pino.logger.ts
@@ -1,4 +1,4 @@
-import type { Logger, Level } from 'pino';
+import type { Logger, Level, Bindings } from 'pino';
 import {
   LoggerService,
   OnApplicationShutdown,
@@ -32,6 +32,29 @@ export class PinoLogger implements LoggerService, OnApplicationShutdown {
       this._logger = pino(options);
     }
   }
+  // native pino levels implementations
+  public child(bindings: Bindings): Logger {
+    return this._logger.child(bindings);
+  }
+  public fatal(_obj: unknown, _msg?: string, ..._args: unknown[]): void;
+  public fatal(_msg: string, ..._args: unknown[]): void;
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+  public fatal(msgOrObject: any, ...args: unknown[]): void {
+    this._logger.fatal(msgOrObject, ...args);
+  }
+  public info(_obj: unknown, _msg?: string, ..._args: unknown[]): void;
+  public info(_msg: string, ..._args: unknown[]): void;
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+  public info(msgOrObject: any, ...args: unknown[]): void {
+    this._logger.info(msgOrObject, ...args);
+  }
+  public trace(_obj: unknown, _msg?: string, ..._args: unknown[]): void;
+  public trace(_msg: string, ..._args: unknown[]): void;
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+  public trace(msgOrObject: any, ...args: unknown[]): void {
+    this._logger.trace(msgOrObject, ...args);
+  }
+  // Nestjs logger service implementation
   public error(msgOrObject: unknown, trace?: string, context?: string): void {
     this.callFunction('error', msgOrObject, context, trace);
   }
@@ -93,10 +116,12 @@ export class PinoLogger implements LoggerService, OnApplicationShutdown {
   private finalHandler(
     err: Error | null,
     finalLogger: Logger,
-    evt: string,
+    evt?: string,
   ): void {
-    finalLogger.info(`${evt} caught`);
-
+    finalLogger.info('Final flushing logs to stdout...');
+    if (evt) {
+      finalLogger.info(`${evt} caught`);
+    }
     if (err) {
       finalLogger.error(err, 'error caused exit');
     }

--- a/test/loggers/pino-logger.spec.ts
+++ b/test/loggers/pino-logger.spec.ts
@@ -7,7 +7,16 @@ chai.use(sinonChai);
 const expect = chai.expect;
 
 describe('Pino logger', () => {
-  const levels = ['error', 'warn', 'log', 'debug', 'verbose'];
+  const levels = [
+    'error',
+    'warn',
+    'log',
+    'debug',
+    'verbose',
+    'fatal',
+    'trace',
+    'info',
+  ];
   afterEach(() => {
     sinon.restore();
   });
@@ -15,6 +24,13 @@ describe('Pino logger', () => {
     const pino = new PinoLogger();
     expect(pino).property('_logger').is.not.undefined;
     expect(pino).not.property('_finalLogger');
+  });
+  it('should return child logger', () => {
+    const pino = new PinoLogger();
+    const stubPinoChild = sinon.stub((pino as any)._logger, 'child');
+    const testOptions = { levels: 'info' };
+    pino.child(testOptions);
+    expect(stubPinoChild).calledOnceWithExactly(testOptions);
   });
   describe('logging', () => {
     let mockPinoLogger: sinon.SinonMock;
@@ -173,7 +189,8 @@ describe('Pino logger', () => {
           testEvent,
         );
         expect(stubFinalLoggerError).not.called;
-        expect(stubFinalLoggerInfo).calledOnceWithExactly(
+        expect(stubFinalLoggerInfo).calledTwice;
+        expect(stubFinalLoggerInfo.secondCall).calledWithExactly(
           `${testEvent} caught`,
         );
       });
@@ -187,6 +204,13 @@ describe('Pino logger', () => {
           testEvent,
         );
         expect(stubFinalLoggerError).calledOnceWith(testError);
+      });
+      it('if no error and no event, should just inform about final handler is working', () => {
+        (pino as any).finalHandler(null, {
+          info: stubFinalLoggerInfo,
+          error: stubFinalLoggerError,
+        });
+        expect(stubFinalLoggerInfo).calledOnce;
       });
     });
   });


### PR DESCRIPTION
Closes #54

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #54

Nestjs Pino logger cannot be used in fastify adapter and default logger in fastify cannot be used as well cuz we need a single configuration entry point for the Pino options and easy extreme mode functionality.

## What is the new behavior?
Added native pino levels to PinoLogger provider. So, it can be injected to FastifyAdapter and in the NestJS application with the `Logger` provider.

```ts
const coreContext = 'NestCore';

const logger = new Logger();
const pinoLogger = new PinoLogger({
  ...config.get('logger'),
  mixin: () => {
    const configMixin = config.get('logger.mixin');
    if (configMixin) {
      return {
        ...configMixin(),
        context: coreContext,
      };
    }
    return {
      context: coreContext,
    };
  },
});

logger.injectLogger(pinoLogger);
logger.setContext(coreContext);
const app = await NestFactory.create<NestFastifyApplication>(
  AppModule,
  new FastifyAdapter({
    logger: pinoLogger,
  }),
  {
    logger,
  },
);
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
